### PR TITLE
ci: Git Flow — dev → staging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,8 @@
 name: Deploy to Production
 
 on:
+  push:
+    branches: [prod]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [main]
+    branches: [staging]
 
 env:
   PROJECT_ID: entraycompara

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,20 +145,32 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
 
 ---
 
-## 4. CI/CD процесс
+## 4. CI/CD процесс & Git Flow
+
+Мы работаем по **Git Flow** с тремя основными ветками:
+
+```
+feature/*  →  dev  →  staging  →  prod
+```
+
+| Ветка | Назначение | Деплой |
+|-------|------------|--------|
+| `dev` | Разработка. Отсюда создаются `feature/*` ветки. | Нет |
+| `staging` | Pre-production / QA. На эту ветку автодеплоится staging. | Auto → `*-staging` (europe-west1) |
+| `prod` | Production. Стабильный код. | Auto на push + Manual (`workflow_dispatch`) → `*` / `*-prod` |
 
 ### Staging деплой (`deploy-staging.yml`)
-**Триггер**: push в `main`
+**Триггер**: push в `staging`
 **Что происходит**:
 1. Сборка и пуш Docker-образа backend
 2. Деплой backend в `backend-upload-service-staging` (europe-west1)
 3. Сборка и пуш Docker-образа landing
-4. Деплой landing в `entraycompara-landing-page-staging` (europe-west1)
+4. Деплой landing в `entraycompara-landing-page-staging` (europe-west1) — на этом сервисе висят домены
 5. Сборка и пуш Docker-образа admin
-6. Деплой admin в `entraycompara-adminpanel-staging` (europe-west1)
+6. Деплой admin в `entraycompara-adminpanel-staging` (europe-west1) — на этом сервисе висят домены
 
 ### Production деплой (`deploy-production.yml`)
-**Триггер**: только ручной запуск (`workflow_dispatch`)
+**Триггер**: push в `prod` или ручной запуск (`workflow_dispatch`)
 **Что происходит**:
 - Те же шаги, но в продакшен-сервисы:
   - `backend-upload-service`
@@ -176,11 +188,13 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
 ### Алгоритм для любого изменения:
 
 1. **Пойми, какой сервис(ы) трогаешь**
-2. **Внеси изменения локально**
-3. **Для фронтендов**: обязательно обнови `compiled/`
-4. **Проверь staging** (автодеплой запустится после push в `main`)
-5. **Убедись, что всё работает на staging URL'ах**
-6. **Только потом** запускай `Deploy to Production` вручную через GitHub Actions
+2. **Создай feature-ветку от `dev`** (или работай напрямую в `dev` для мелких фиксов)
+3. **Внеси изменения локально**
+4. **Для фронтендов**: обязательно обнови `compiled/`
+5. **Замерджи в `dev`, затем в `staging`**
+6. **Проверь staging** (автодеплой запустится после push в `staging`)
+7. **Убедись, что всё работает на staging URL'ах**
+8. **Только потом** создавай PR / мердж `staging → prod` (или запускай `Deploy to Production` вручную)
 
 ### Что НЕЛЬЗЯ делать без разрешения пользователя:
 - Запускать production-деплой

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ entraycompara-platform/
 │   ├── cloud-run-configs/         # JSON-конфигурации Cloud Run
 │   └── cloud-build-triggers.json  # Старые Cloud Build триггеры
 ├── .github/workflows/
-│   ├── deploy-staging.yml         # Автодеплой в staging
-│   └── deploy-production.yml      # Ручной деплой в продакшен
+│   ├── deploy-staging.yml         # Автодеплой в staging (preprod)
+│   └── deploy-production.yml      # Авто/ручной деплой в продакшен
 ├── AGENTS.md                      # ← Обязательно к прочтению для разработчиков
 └── README.md                      # Этот файл
 ```
@@ -68,17 +68,29 @@ entraycompara-platform/
 
 ---
 
-## CI/CD
+## CI/CD & Git Flow
+
+Мы используем **Git Flow** с тремя основными ветками:
+
+```
+feature/*  →  dev  →  staging  →  prod
+```
+
+| Ветка | Назначение | Триггер деплоя |
+|-------|------------|----------------|
+| `dev` | Активная разработка. От неё создаются `feature/*` ветки. | Нет |
+| `staging` | Pre-production / QA. Именно здесь висят домены `entraycompara.com` и `crm.entraycompara.com`. | **Auto** на push в `staging` → `*-staging` (europe-west1) |
+| `prod` | Production. Стабильный код для реальных пользователей. | **Auto** на push в `prod` + **Manual** (`workflow_dispatch`) → `*` / `*-prod` |
 
 ### Staging (автоматический деплой)
-**Триггер**: push в `main`
+**Триггер**: push в `staging`
 
-При каждом push GitHub Actions собирает Docker-образы всех трёх приложений и деплоит их в staging-сервисы в `europe-west1`.
+При каждом push GitHub Actions собирает Docker-образы всех трёх приложений и деплоит их в staging-сервисы в `europe-west1`, к которым привязаны боевые домены.
 
-### Production (ручной деплой)
-**Триггер**: `workflow_dispatch` в GitHub Actions
+### Production (авто + ручной деплой)
+**Триггер**: push в `prod` или ручной запуск `workflow_dispatch`
 
-Запускается вручную через вкладку **Actions → Deploy to Production → Run workflow**.
+Запускается автоматически при merge `staging → prod`, либо вручную через **Actions → Deploy to Production → Run workflow**.
 
 ### GitHub Secrets
 - `GCP_SA_KEY` — ключ сервисного аккаунта для GCP


### PR DESCRIPTION
Настройка Git Flow:
- dev — ветка разработки
- staging — preprod с автодеплоем в *-staging (где сейчас домены)
- prod — production с автодеплоем + manual dispatch

Изменения:
- deploy-staging.yml триггерится на push в staging
- deploy-production.yml триггерится на push в prod и workflow_dispatch
- Обновлена документация (README.md, AGENTS.md)