### PR TITLE
Add post-submit acceptance QA suite

### DIFF
--- a/apps/backend-upload-service/main.py
+++ b/apps/backend-upload-service/main.py
@@ -3402,11 +3402,15 @@ def parse_whatsapp_activation_text(text: str) -> tuple[str, str] | None:
         return None
     public_code = f"EC-{public_code_match.group(1)}"
 
-    compact_text = re.sub(r"\D", "", text)
-    code_match = re.search(r"(\d{6})(?!.*\d{6})", compact_text)
-    if not code_match:
+    verification_tail = text[public_code_match.end():]
+    tail_codes = re.findall(r"\d{6}", re.sub(r"\D", "", verification_tail))
+    if tail_codes:
+        return public_code, tail_codes[-1]
+
+    all_codes = re.findall(r"\d{6}", re.sub(r"\D", "", text))
+    if len(all_codes) < 2:
         return None
-    return public_code, code_match.group(1)
+    return public_code, all_codes[-1]
 
 
 def create_whatsapp_timeline_event(

--- a/apps/backend-upload-service/tests/test_sales_department.py
+++ b/apps/backend-upload-service/tests/test_sales_department.py
@@ -41,6 +41,7 @@ def install_dependency_stubs():
     fastapi.Query = passthrough_default
     fastapi.Header = passthrough_default
     fastapi.Body = passthrough_default
+    fastapi.Request = object
     fastapi.status = types.SimpleNamespace(
         HTTP_201_CREATED=201,
         HTTP_204_NO_CONTENT=204,
@@ -221,6 +222,71 @@ class SalesDepartmentAutopilotTests(unittest.TestCase):
         self.assertFalse(result["enabled"])
         self.assertFalse(result["safe_to_send"])
         self.assertIn("sales_automation_disabled", result["blocked_reasons"])
+
+
+class PostSubmitSecurityHelperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main = load_main()
+
+    def test_verification_code_generation_and_formatting(self):
+        code = self.main.generate_verification_code()
+
+        self.assertRegex(code, r"^\d{6}$")
+        self.assertEqual(self.main.format_verification_code("739284"), "739 284")
+
+    def test_client_secret_hash_does_not_store_plaintext(self):
+        value = "739284"
+        hashed = self.main.hash_client_secret(value)
+
+        self.assertNotEqual(hashed, value)
+        self.assertEqual(hashed, self.main.hash_client_secret(value))
+        self.assertRegex(hashed, r"^[a-f0-9]{64}$")
+
+    def test_parse_whatsapp_activation_text(self):
+        parsed = self.main.parse_whatsapp_activation_text(
+            "Hola, soy cliente de Entra y Compara. Mi código es EC-482913 / 739284."
+        )
+
+        self.assertEqual(parsed, ("EC-482913", "739284"))
+
+    def test_verification_attempt_window_limits_short_bursts(self):
+        now = self.main.datetime.datetime(2026, 5, 1, 12, 0, 0)
+        app_data = {
+            "verification_code_attempt_window_started_at": now - self.main.datetime.timedelta(seconds=30),
+            "verification_code_attempt_window_count": 4,
+        }
+
+        window_started_at, window_count = self.main.get_verification_attempt_window(app_data, now)
+        update = self.main.build_verification_attempt_update(2, window_started_at, window_count, now)
+
+        self.assertEqual(window_count, 4)
+        self.assertEqual(update["verification_code_attempts"], 3)
+        self.assertEqual(update["verification_code_attempt_window_count"], 5)
+
+    def test_verification_attempt_window_resets_after_timeout(self):
+        now = self.main.datetime.datetime(2026, 5, 1, 12, 0, 0)
+        app_data = {
+            "verification_code_attempt_window_started_at": now - self.main.datetime.timedelta(seconds=120),
+            "verification_code_attempt_window_count": 5,
+        }
+
+        window_started_at, window_count = self.main.get_verification_attempt_window(app_data, now)
+
+        self.assertEqual(window_started_at, now)
+        self.assertEqual(window_count, 0)
+
+    def test_meta_signature_validation(self):
+        raw_body = b'{"entry":[]}'
+        self.main.WHATSAPP_APP_SECRET = "test-secret"
+        signature = self.main.hmac.new(
+            b"test-secret",
+            raw_body,
+            self.main.hashlib.sha256,
+        ).hexdigest()
+
+        self.assertTrue(self.main.verify_meta_signature(raw_body, f"sha256={signature}"))
+        self.assertFalse(self.main.verify_meta_signature(raw_body, "sha256=bad"))
 
 
 if __name__ == "__main__":

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@
 | `sales-department-rollout.md` | Rollout, kill switch и проверка Sales Department |
 | `roadmap-sales-department-autopilot.md` | Roadmap автопилота обработки лидов |
 | `tz-post-submit-client-area.md` | Актуальное ТЗ post-submit flow, WhatsApp-активации и личного кабинета клиента |
+| `security-gdpr-guardrails.md` | Security/GDPR guardrails для кодов, токенов, webhook и GCS signed URL migration |
+| `post-submit-client-area-qa.md` | QA checklist и safe E2E-план для post-submit/client area MVP |
 
 ## Технические задания и проектный архив
 
@@ -25,4 +27,4 @@
 
 Если фактическое поведение кода конфликтует с историческим ТЗ, приоритет у текущего кода, `README.md`, `AGENTS.md` и актуальных rollout-документов.
 
-Документ актуален на: 30 апреля 2026.
+Документ актуален на: 1 мая 2026.

--- a/docs/post-submit-client-area-qa.md
+++ b/docs/post-submit-client-area-qa.md
@@ -1,0 +1,82 @@
+# Post-submit and client area QA checklist
+
+This checklist validates the MVP flow without creating unnecessary production-like data.
+
+## Important staging warning
+
+Staging backend uses the same Firestore, GCS bucket, email secrets, and WhatsApp configuration as the live environment. Do not run load tests, repeated form submissions, or fake WhatsApp campaigns against staging. Use one clearly named QA lead per test pass and delete or mark it after verification.
+
+Recommended QA marker:
+
+- Client name: `QA Post Submit <date>`
+- Email: internal test inbox only
+- Notes: `QA post-submit/client-area acceptance test`
+
+## Backend helper checks
+
+Run from the repository root:
+
+```powershell
+python -m unittest apps.backend-upload-service.tests.test_sales_department
+```
+
+The suite covers:
+
+- verification code generation and display formatting;
+- client secret hashing for verification codes and secure tokens;
+- WhatsApp activation text parsing;
+- verification attempt window behaviour;
+- Meta webhook signature validation helper;
+- existing sales-department guardrails.
+
+## Manual E2E checklist
+
+1. Submit a factura through the landing page using a small PDF/JPG/PNG and QA marker data.
+2. Confirm the backend response contains `public_code`, `verification_code_display`, `verification_code_expires_at`, `whatsapp_url`, and no plaintext secure token.
+3. Confirm the Firestore application has `verification_code_hash`, `secure_token_hash`, `client_visible_status`, `consent_version`, source/UTM fields, and no plaintext `verification_code` or `secure_token`.
+4. Confirm the post-submit screen shows `Hemos recibido tu factura`, tracking code, WhatsApp activation code, timeline, and a WhatsApp CTA.
+5. Open the WhatsApp URL and verify the prefilled text contains the backend phone number and the expected `EC-xxxxxx / xxxxxx` code.
+6. Send the activation message from the client WhatsApp number.
+7. Confirm the webhook sets `whatsapp_verified`, `client_area_enabled`, `client_area_url`, and creates security/timeline events.
+8. Open `/area/c/{secure_token}` from the WhatsApp reply and confirm the client sees status, client data, files, extracted data if available, simulations if available, proposal if available, and WhatsApp CTA.
+9. Open `/area/c/invalid-token` and confirm the response is generic and does not reveal any private lead data.
+10. Send an incorrect activation code and confirm the client receives a generic validation error while the CRM/security events record the failed attempt.
+11. Force or wait for an expired code and confirm the expired-code response is generic and the lead is not activated.
+12. In CRM, search the lead by `public_code` and confirm status, WhatsApp verification, client area state, and timeline are visible.
+13. Revoke the client area token from the management endpoint and confirm the old secure link no longer opens.
+14. Generate or upload a proposal and confirm verified WhatsApp clients receive the client-area link while unverified clients are not auto-notified.
+
+## Frontend smoke plan
+
+Landing page:
+
+- the upload/post-submit flow renders in Spanish;
+- WhatsApp activation CTA uses backend-provided URL;
+- mobile layout keeps tracking code, activation code, timeline, and reassurance text visible;
+- the page does not promise completion in a few seconds.
+
+Client area:
+
+- valid token renders status summary, files, extracted data, simulations, proposal, events, and CTAs;
+- invalid token renders a generic not-found state;
+- proposal-ready and proposal-accepted states are visually clear;
+- mobile layout is one-column and CTA buttons remain usable.
+
+CRM:
+
+- public code is visible in the lead card/detail view;
+- WhatsApp verified/client-area badges match backend state;
+- timeline shows activation, proposal notification, and security-relevant notes;
+- old leads without `public_code`, `client_visible_status`, or client-area fields still render without crashing.
+
+## Safe automated E2E plan
+
+Do not automate public submit against shared staging by default. For CI, prefer a future isolated Firebase/GCS project or a mocked backend.
+
+When an isolated test environment exists, automate:
+
+- submit factura creates application and file metadata;
+- webhook activation enables client area;
+- invalid webhook payload is rejected;
+- client area valid/invalid token flows;
+- CRM search by public code.


### PR DESCRIPTION
## Summary
- add backend helper tests for post-submit code generation, hashing, parsing, rate-window logic, and Meta signature validation
- fix WhatsApp activation parser so it does not select overlapping digits from the EC public code
- add manual QA checklist and safe frontend/e2e smoke plan for post-submit and client area
- link the QA checklist from docs README

## Validation
- python -m unittest apps.backend-upload-service.tests.test_sales_department
- python -m py_compile apps/backend-upload-service/main.py
- git diff --check

Closes #66